### PR TITLE
Add mathematically-inspired generative background patterns

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
 
     const canvas = document.getElementById('pattern');
     const ctx = canvas.getContext('2d');
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     const randomInRange = (min, max) => min + Math.random() * (max - min);
 
@@ -127,41 +128,63 @@
       return a;
     };
 
-    const drawPattern = () => {
-      const dpr = window.devicePixelRatio || 1;
-      const width = window.innerWidth;
-      const height = window.innerHeight;
+    const makeFamily = (width, height) => {
+      let a = Math.floor(randomInRange(2, 10));
+      let b = Math.floor(randomInRange(3, 11));
 
+      while (gcd(a, b) !== 1) {
+        a = Math.floor(randomInRange(2, 10));
+        b = Math.floor(randomInRange(3, 11));
+      }
+
+      return {
+        a,
+        b,
+        basePhase: randomInRange(0, Math.PI * 2),
+        phaseVelocity: randomInRange(-0.34, 0.34),
+        centerX: randomInRange(width * 0.18, width * 0.82),
+        centerY: randomInRange(height * 0.18, height * 0.82),
+        radiusX: randomInRange(width * 0.12, width * 0.34),
+        radiusY: randomInRange(height * 0.12, height * 0.3),
+        stroke: `hsla(${Math.floor(randomInRange(195, 240))}, 90%, ${Math.floor(randomInRange(62, 78))}%, ${randomInRange(0.12, 0.22).toFixed(3)})`,
+        lineWidth: randomInRange(0.9, 1.6),
+      };
+    };
+
+    let width = window.innerWidth;
+    let height = window.innerHeight;
+    let families = [];
+    const familyCount = 3;
+    const steps = 1400;
+    let animationFrameId = null;
+    const startTime = performance.now();
+
+    const resizeCanvas = () => {
+      const dpr = window.devicePixelRatio || 1;
+      width = window.innerWidth;
+      height = window.innerHeight;
       canvas.width = Math.floor(width * dpr);
       canvas.height = Math.floor(height * dpr);
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    const regenerateFamilies = () => {
+      families = Array.from({ length: familyCount }, () => makeFamily(width, height));
+    };
+
+    const drawPattern = (elapsedMs = 0) => {
+      const seconds = elapsedMs / 1000;
       ctx.clearRect(0, 0, width, height);
 
-      const familyCount = 3;
-
-      for (let i = 0; i < familyCount; i += 1) {
-        let a = Math.floor(randomInRange(2, 10));
-        let b = Math.floor(randomInRange(3, 11));
-
-        while (gcd(a, b) !== 1) {
-          a = Math.floor(randomInRange(2, 10));
-          b = Math.floor(randomInRange(3, 11));
-        }
-
-        const phase = randomInRange(0, Math.PI * 2);
-        const steps = 1400;
-        const loops = 2 * Math.PI;
-        const centerX = randomInRange(width * 0.18, width * 0.82);
-        const centerY = randomInRange(height * 0.18, height * 0.82);
-        const radiusX = randomInRange(width * 0.12, width * 0.34);
-        const radiusY = randomInRange(height * 0.12, height * 0.3);
-
+      for (const family of families) {
         ctx.beginPath();
 
         for (let step = 0; step <= steps; step += 1) {
-          const t = (step / steps) * loops;
-          const x = centerX + radiusX * Math.sin(a * t + phase);
-          const y = centerY + radiusY * Math.sin(b * t);
+          const t = (step / steps) * (Math.PI * 2);
+          const phase = family.basePhase + family.phaseVelocity * seconds;
+          const x = family.centerX + family.radiusX * Math.sin(family.a * t + phase);
+          const y = family.centerY + family.radiusY * Math.sin(family.b * t - phase * 0.55);
+
           if (step === 0) {
             ctx.moveTo(x, y);
           } else {
@@ -169,17 +192,41 @@
           }
         }
 
-        const lightness = Math.floor(randomInRange(62, 78));
-        const alpha = randomInRange(0.14, 0.24).toFixed(3);
-        ctx.strokeStyle = `hsla(${Math.floor(randomInRange(195, 240))}, 90%, ${lightness}%, ${alpha})`;
-        ctx.lineWidth = randomInRange(0.9, 1.6);
+        ctx.strokeStyle = family.stroke;
+        ctx.lineWidth = family.lineWidth;
         ctx.stroke();
       }
     };
 
-    drawPattern();
-    window.addEventListener('resize', drawPattern);
-    window.addEventListener('click', drawPattern);
+    const animate = (now) => {
+      drawPattern(now - startTime);
+      animationFrameId = window.requestAnimationFrame(animate);
+    };
+
+    const restart = () => {
+      resizeCanvas();
+      regenerateFamilies();
+      drawPattern(0);
+    };
+
+    restart();
+
+    if (!prefersReducedMotion) {
+      animationFrameId = window.requestAnimationFrame(animate);
+    }
+
+    window.addEventListener('resize', restart);
+    window.addEventListener('click', () => {
+      regenerateFamilies();
+      if (prefersReducedMotion) {
+        drawPattern(0);
+      }
+    });
+    window.addEventListener('beforeunload', () => {
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+    });
   </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,17 @@
       background:
         radial-gradient(700px 400px at 85% -10%, rgba(110, 168, 255, .22), transparent 62%),
         linear-gradient(165deg, #08101e 0%, #0b1220 60%, #121d32 100%);
+      overflow: hidden;
+      position: relative;
+    }
+
+    #pattern {
+      position: fixed;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 0;
+      pointer-events: none;
     }
 
     .card {
@@ -39,6 +50,8 @@
       box-shadow: var(--shadow);
       padding: 2rem;
       text-align: center;
+      position: relative;
+      z-index: 1;
     }
 
     h1 {
@@ -84,6 +97,8 @@
   </style>
 </head>
 <body>
+  <canvas id="pattern" aria-hidden="true"></canvas>
+
   <main class="card">
     <h1>Zachary Glassman</h1>
     <p>Data professional.</p>
@@ -99,6 +114,72 @@
 
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
+
+    const canvas = document.getElementById('pattern');
+    const ctx = canvas.getContext('2d');
+
+    const randomInRange = (min, max) => min + Math.random() * (max - min);
+
+    const gcd = (a, b) => {
+      while (b !== 0) {
+        [a, b] = [b, a % b];
+      }
+      return a;
+    };
+
+    const drawPattern = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+
+      canvas.width = Math.floor(width * dpr);
+      canvas.height = Math.floor(height * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, width, height);
+
+      const familyCount = 3;
+
+      for (let i = 0; i < familyCount; i += 1) {
+        let a = Math.floor(randomInRange(2, 10));
+        let b = Math.floor(randomInRange(3, 11));
+
+        while (gcd(a, b) !== 1) {
+          a = Math.floor(randomInRange(2, 10));
+          b = Math.floor(randomInRange(3, 11));
+        }
+
+        const phase = randomInRange(0, Math.PI * 2);
+        const steps = 1400;
+        const loops = 2 * Math.PI;
+        const centerX = randomInRange(width * 0.18, width * 0.82);
+        const centerY = randomInRange(height * 0.18, height * 0.82);
+        const radiusX = randomInRange(width * 0.12, width * 0.34);
+        const radiusY = randomInRange(height * 0.12, height * 0.3);
+
+        ctx.beginPath();
+
+        for (let step = 0; step <= steps; step += 1) {
+          const t = (step / steps) * loops;
+          const x = centerX + radiusX * Math.sin(a * t + phase);
+          const y = centerY + radiusY * Math.sin(b * t);
+          if (step === 0) {
+            ctx.moveTo(x, y);
+          } else {
+            ctx.lineTo(x, y);
+          }
+        }
+
+        const lightness = Math.floor(randomInRange(62, 78));
+        const alpha = randomInRange(0.14, 0.24).toFixed(3);
+        ctx.strokeStyle = `hsla(${Math.floor(randomInRange(195, 240))}, 90%, ${lightness}%, ${alpha})`;
+        ctx.lineWidth = randomInRange(0.9, 1.6);
+        ctx.stroke();
+      }
+    };
+
+    drawPattern();
+    window.addEventListener('resize', drawPattern);
+    window.addEventListener('click', drawPattern);
   </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Add subtle, mathematically interesting visual flair to the page without changing content or layout by rendering randomized geometric line patterns behind the main card.

### Description
- Add a full-screen fixed `<canvas id="pattern">` layer and update stacking so the `.card` stays visually in front while the canvas renders behind it.
- Implement a device-pixel-ratio aware `drawPattern()` routine that generates multiple Lissajous-style families using coprime frequency pairs (via `gcd`) and randomized phases, centers, radii, colors, and stroke widths to produce varied closed curves.
- Make the canvas high-DPI friendly with `ctx.setTransform(...)`, clear and redraw on initial load, and re-render on `resize` and `click` so visitors can refresh the background interactively.

### Testing
- Served the site with `python3 -m http.server 4173` and confirmed the page loads successfully (automated local server run succeeded).
- Ran a Playwright script to open `http://127.0.0.1:4173`, wait for render, and capture a screenshot which completed successfully (screenshot artifact created).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69928c02a2dc8322860026dc9bad0182)